### PR TITLE
[as4630-54pe] Support system health

### DIFF
--- a/device/accton/x86_64-accton_as4630_54pe-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as4630_54pe-r0/sonic_platform/chassis.py
@@ -17,7 +17,7 @@ except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
 NUM_FAN_TRAY = 3
-NUM_FAN = 1
+NUM_FAN = 2
 NUM_PSU = 2
 NUM_THERMAL = 3
 PORT_START = 49

--- a/device/accton/x86_64-accton_as4630_54pe-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as4630_54pe-r0/sonic_platform/chassis.py
@@ -17,7 +17,7 @@ except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
 NUM_FAN_TRAY = 3
-NUM_FAN = 2
+NUM_FAN = 1
 NUM_PSU = 2
 NUM_THERMAL = 3
 PORT_START = 49
@@ -28,6 +28,13 @@ PMON_REBOOT_CAUSE_PATH = "/usr/share/sonic/platform/api_files/reboot-cause/"
 REBOOT_CAUSE_FILE = "reboot-cause.txt"
 PREV_REBOOT_CAUSE_FILE = "previous-reboot-cause.txt"
 HOST_CHK_CMD = "docker > /dev/null 2>&1"
+SYSLED_FNODE = "/sys/class/leds/diag/brightness"
+SYSLED_MODES = {
+    "0" : "STATUS_LED_COLOR_OFF",
+    "1" : "STATUS_LED_COLOR_GREEN",
+    "2" : "STATUS_LED_COLOR_AMBER",
+    "5" : "STATUS_LED_COLOR_GREEN_BLINK"
+}
 
 
 class Chassis(ChassisBase):
@@ -56,12 +63,15 @@ class Chassis(ChassisBase):
         self.sfp_module_initialized = True
         
     def __initialize_fan(self):
-        from sonic_platform.fan import Fan
+        from sonic_platform.fan import Fan, FanDrawer
         for fant_index in range(0, NUM_FAN_TRAY):
+            drawer = FanDrawer()
+            self._fan_drawer_list.append(drawer)
             for fan_index in range(0, NUM_FAN):
                 fan = Fan(fant_index, fan_index)
                 self._fan_list.append(fan)
-                
+                drawer._fan_list.append(fan)
+
     def __initialize_psu(self):
         from sonic_platform.psu import Psu
         for index in range(0, NUM_PSU):
@@ -211,3 +221,21 @@ class Chassis(ChassisBase):
             sys.stderr.write("SFP index {} out of range (1-{})\n".format(
                              index, len(self._sfp_list)))
         return sfp
+
+    def initizalize_system_led(self):
+        return
+
+    def get_status_led(self):
+        val = self._api_helper.read_txt_file(SYSLED_FNODE)
+        return SYSLED_MODES[val] if val in SYSLED_MODES else "UNKNOWN"
+
+    def set_status_led(self, color):
+        mode = None
+        for key, val in SYSLED_MODES.items():
+            if val == color:
+                mode = key
+                break
+        if mode is None:
+            return False
+        else:
+            return self._api_helper.write_txt_file(SYSLED_FNODE, mode)

--- a/device/accton/x86_64-accton_as4630_54pe-r0/sonic_platform/fan.py
+++ b/device/accton/x86_64-accton_as4630_54pe-r0/sonic_platform/fan.py
@@ -36,7 +36,8 @@ FANLED_MODES = {
     "1": FanBase.STATUS_LED_COLOR_GREEN,
     "2": FanBase.STATUS_LED_COLOR_AMBER
 }
-
+FAN_NAME_LIST = ["FAN-1F", "FAN-1R", "FAN-2F", "FAN-2R",
+                 "FAN-3F", "FAN-3R"]
 
 class Fan(FanBase):
     """Platform-specific Fan class"""
@@ -192,10 +193,10 @@ class Fan(FanBase):
             Returns:
             string: The name of the device
         """
-        if not self.is_psu_fan:
-            fan_name = "FAN-{}".format(self.fan_tray_index+1)
-        else:
-            fan_name = "PSU-{} FAN-{}".format(self.psu_index+1, self.fan_index+1)
+        fan_name = FAN_NAME_LIST[self.fan_tray_index*2 + self.fan_index] \
+            if not self.is_psu_fan \
+            else "PSU-{} FAN-{}".format(self.psu_index+1, self.fan_index+1)
+
         return fan_name
             
     def get_presence(self):

--- a/device/accton/x86_64-accton_as4630_54pe-r0/sonic_platform/helper.py
+++ b/device/accton/x86_64-accton_as4630_54pe-r0/sonic_platform/helper.py
@@ -51,7 +51,7 @@ class APIHelper():
 
     def read_txt_file(self, file_path):
         try:
-            with open(file_path, 'r') as fd:
+            with open(file_path, 'r', errors='replace') as fd:
                 data = fd.read()
                 return data.strip()
         except IOError:

--- a/device/accton/x86_64-accton_as4630_54pe-r0/system_health_monitoring_config.json
+++ b/device/accton/x86_64-accton_as4630_54pe-r0/system_health_monitoring_config.json
@@ -1,0 +1,16 @@
+{
+    "services_to_ignore": [],
+    "devices_to_ignore": [
+        "asic",
+        "psu.temperature",
+        "PSU-1 FAN-1.speed",
+        "PSU-2 FAN-1.speed"
+    ],
+    "user_defined_checkers": [],
+    "polling_interval": 60,
+    "led_color": {
+        "fault": "STATUS_LED_COLOR_AMBER",
+        "normal": "STATUS_LED_COLOR_GREEN",
+        "booting": "STATUS_LED_COLOR_GREEN_BLINK"
+    }
+}

--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/modules/x86-64-accton-as4630-54pe-cpld.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/modules/x86-64-accton-as4630-54pe-cpld.c
@@ -498,11 +498,11 @@ static ssize_t set_duty_cycle(struct device *dev, struct device_attribute *da,
 
 static u8 reg_val_to_direction(u8 reg_val, enum fan_id id)
 {
-    u8 mask = (1 << id);
+    u8 mask = (1 << (4 + id));
 
     reg_val &= mask;
 
-    return reg_val ? 1 : 0;
+    return reg_val ? 0 : 1;
 }
 
 static u8 reg_val_to_is_present(u8 reg_val, enum fan_id id)

--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/modules/x86-64-accton-as4630-54pe-leds.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/modules/x86-64-accton-as4630-54pe-leds.c
@@ -74,10 +74,10 @@ static struct accton_as4630_54pe_led_data  *ledctl = NULL;
 #define LED_MODE_STK2_GREEN_VALUE       0x0
 #define LED_MODE_STK2_OFF_VALUE	        0x10
 
-#define LED_TYPE_FAN_REG_MASK           (0x20|0x10)
-#define LED_MODE_FAN_AMBER_VALUE        0x20
-#define LED_MODE_FAN_GREEN_VALUE        0x10
-#define LED_MODE_FAN_OFF_VALUE	        (0x0)
+#define LED_TYPE_FAN_REG_MASK           (0x8|0x4)
+#define LED_MODE_FAN_AMBER_VALUE        0x8
+#define LED_MODE_FAN_GREEN_VALUE        0x4
+#define LED_MODE_FAN_OFF_VALUE	        (0xC)
 
 #define LED_TYPE_PSU2_REG_MASK          (0x8|0x4)
 #define LED_MODE_PSU2_AMBER_VALUE        0x8
@@ -371,7 +371,7 @@ static void accton_as4630_54pe_led_fan_set(struct led_classdev *led_cdev,
 static enum led_brightness accton_as4630_54pe_led_fan_get(struct led_classdev *cdev)
 {
     accton_as4630_54pe_led_update();
-    return led_reg_val_to_light_mode(LED_TYPE_FAN, ledctl->reg_val[0]);
+    return led_reg_val_to_light_mode(LED_TYPE_FAN, ledctl->reg_val[1]);
 }
 
 static void accton_as4630_54pe_led_psu1_set(struct led_classdev *led_cdev,
@@ -405,7 +405,7 @@ static struct led_classdev accton_as4630_54pe_leds[] = {
         .brightness_set	 = accton_as4630_54pe_led_diag_set,
         .brightness_get	 = accton_as4630_54pe_led_diag_get,
         .flags			 = LED_CORE_SUSPENDRESUME,
-        .max_brightness	 = LED_MODE_GREEN,
+        .max_brightness	 = LED_MODE_GREEN_BLINK,
     },
     [LED_TYPE_PRI] = {
         .name			 = "pri",


### PR DESCRIPTION
1. Implement SysLed on chassis.
2. Correct fan number, fan.get_direction() and get_presence()
3. Implement required fan APIs for SystemHealth to check fan.speed
4. Correct LED registers.
5. For psud's sake, handle non-utf8 character while reading PSU model

Signed-off-by: Sean Wu <sean_wu@edge-core.com>

JIRA: https://jira.edge-core.com:8443/browse/ONSBUSWI-1191